### PR TITLE
Use system properties for RateLimitedClient

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -125,7 +125,7 @@ class RateLimitedClient implements AutoCloseable {
         LOG.debug("rate limited call delay: {}", delay);
         NvdApiRetryStrategy retryStrategy = new NvdApiRetryStrategy(maxRetries, minimumDelay);
         SystemDefaultRoutePlanner planner = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
-        client = HttpAsyncClients.custom().setRoutePlanner(planner).setRetryStrategy(retryStrategy).build();
+        client = HttpAsyncClients.custom().setRoutePlanner(planner).setRetryStrategy(retryStrategy).useSystemProperties().build();
         client.start();
     }
 


### PR DESCRIPTION
To enable proxy authentication, use the system properties to configure the HttpClient.